### PR TITLE
Fix next.js typescript errors

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,10 +1,10 @@
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
+import Image from 'next/image'
 import { PostMetadata } from '@/components/blog/PostMetadata'
 import PostNavigation from '@/components/blog/PostNavigation'
 import { getAllPosts, getPostBySlug } from '@/lib/mdx'
 import { compileMDX } from 'next-mdx-remote/rsc'
-import { useMDXComponents } from '@/lib/mdx-components'
 
 interface PostPageProps {
   params: Promise<{
@@ -39,8 +39,21 @@ export default async function PostPage({ params }: PostPageProps) {
   const previousPost = postIndex > 0 ? posts[postIndex - 1] : null
   const nextPost = postIndex < posts.length - 1 ? posts[postIndex + 1] : null
 
-  // Compile MDX content here
-  const mdxComponents = useMDXComponents()
+  // Define MDX components directly instead of using the hook
+  const mdxComponents = {
+    Signature: () => (
+      <div style={{ textAlign: 'left', width: '100%' }}>
+        <Image
+          src="https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/5abd08ee-bc4d-49f0-9303-3d5d75ef4359/email_signatures.png?t=1742411231"
+          alt="Signature"
+          width={200}
+          height={100}
+          style={{ width: '33%', height: 'auto', display: 'inline-block' }}
+        />
+      </div>
+    ),
+  }
+
   const { content: compiledContent } = await compileMDX({
     source: post.content,
     components: mdxComponents,


### PR DESCRIPTION
The `React Hook "useMDXComponents" cannot be called in an async function` error in `src/app/blog/[slug]/page.tsx` was addressed.

The `useMDXComponents()` hook was being called within an async Next.js server component, which violates React's Rules of Hooks.

The fix involved:
*   Removing the `import { useMDXComponents } from '@/lib/mdx-components'` statement.
*   Replacing the `const mdxComponents = useMDXComponents()` call with a direct definition of the `mdxComponents` object. This object now directly contains the `Signature` component, mirroring the functionality previously provided by the hook.
*   Adding `import Image from 'next/image'` to support the `Image` component used within the `Signature` component's definition.

This change ensures that React hooks are not used in server components, resolving the build error while maintaining the intended rendering of MDX content and the `Signature` component. The linter and build now pass successfully.