### PR TITLE
Add store links to header, footer, and links page

### DIFF
--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -103,6 +103,15 @@ const supportLinks: LinkItem[] = [
   }
 ]
 
+// Shop links section
+const shopLinks: LinkItem[] = [
+  {
+    name: 'Sticky Spells Store',
+    url: 'https://www.pythoness.store',
+    color: 'bg-brand-green-accent text-brand-green-dark hover:bg-brand-green-accent/90'
+  }
+]
+
 // Media links section
 const mediaLinks: LinkItem[] = [
   {
@@ -227,6 +236,26 @@ export default function LinksPage() {
               <h2 className="font-display text-xl text-white text-center">Book a Call</h2>
               <div className="space-y-3">
                 {bookingLinks.map((link) => (
+                  <Link
+                    key={link.name}
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`block ${link.color} py-2.5 md:py-3 px-6 rounded-lg text-center transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-brand-green-accent focus:ring-offset-2 focus:ring-offset-brand-green-dark font-medium`}
+                  >
+                    {link.name}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Shop Links */}
+          {shopLinks.length > 0 && (
+            <div className="space-y-3">
+              <h2 className="font-display text-xl text-white text-center">Shop</h2>
+              <div className="space-y-3">
+                {shopLinks.map((link) => (
                   <Link
                     key={link.name}
                     href={link.url}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -34,6 +34,7 @@ export default function Footer() {
               <li><Link href="/about" className={footerLinkClass}>About</Link></li>
               <li><Link href="/services" className={footerLinkClass}>Services</Link></li>
               <li><Link href="/resources" className={footerLinkClass}>Resources</Link></li>
+              <li><Link href="https://www.pythoness.store" target="_blank" rel="noopener noreferrer" className={`${footerLinkClass} font-medium`}>Shop - Sticky Spells</Link></li>
             </ul>
           </FooterSection>
           {/* Social Links */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -63,6 +63,14 @@ export default function Header() {
               Blog
             </Link>
             <Link 
+              href="https://www.pythoness.store" 
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white hover:text-brand-green-accent transition-colors focus:outline-none focus:ring-2 focus:ring-brand-green-accent focus:ring-offset-2 rounded-lg px-2 py-1 font-medium"
+            >
+              Shop
+            </Link>
+            <Link 
               href="https://cal.com/pythoness" 
               target="_blank"
               className="bg-brand-green-accent text-white px-4 py-2 rounded-lg hover:bg-opacity-90 transition-all focus:outline-none focus:ring-2 focus:ring-brand-green-accent focus:ring-offset-2"
@@ -146,6 +154,15 @@ export default function Header() {
             onClick={() => setIsMenuOpen(false)}
           >
             Blog
+          </Link>
+          <Link 
+            href="https://www.pythoness.store" 
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-white hover:text-brand-green-accent transition-colors focus:outline-none focus:ring-2 focus:ring-brand-green-accent focus:ring-offset-2 rounded-lg px-2 py-1 font-medium"
+            onClick={() => setIsMenuOpen(false)}
+          >
+            Shop
           </Link>
           <Link 
             href="https://cal.com/pythoness" 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add "Shop" link for the new "Sticky Spells" store to the Header, Footer, and Links page for prominent visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cc1730f-49f6-4aba-89f5-7c730f99b827">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cc1730f-49f6-4aba-89f5-7c730f99b827">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>